### PR TITLE
upgrade to Ruby 2.6.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.6.3'
+ruby '2.6.6'
 
 gem 'activesupport'
 gem 'airrecord'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ DEPENDENCIES
   tzinfo
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.6.6p146
 
 BUNDLED WITH
-   1.17.2
+   2.1.4


### PR DESCRIPTION
not sure if we need anything else for this to work on Heroku, or even if this change is desirable.

Upgrades in 2.6.4, 2.6.5, and 2.6.6 were all security stuff. Looks like there's one JSON vuln: https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/ . I'm not sure if this project would be vulnerable but I'm running the server locally in 2.6.6 without issue.