### PR TITLE
Handle exclusion from carousel via Airtable

### DIFF
--- a/events_airtable.rb
+++ b/events_airtable.rb
@@ -50,14 +50,14 @@ class EventTypeDictionary < Airrecord::Table
       old_et = entry[:event_type].to_s.strip.downcase
       new_et = dict[source][old_et]
 
-      if new_et['exclude_from_map']
-        # This event type has specifically been excluded from the map
-        puts "Skipping specifically-excluded #{source} event type #{entry[:event_type].inspect} for #{entry[:event_title]}"
-        next
-      elsif new_et.blank?
+      if new_et.blank?
         # This event type is unrecognized; warn but keep it
         puts "Unmapped #{source} event type #{entry[:event_type].inspect} for #{entry[:event_title]}"
         list << entry
+      elsif new_et['exclude_from_map']
+        # This event type has specifically been excluded from the map
+        puts "Skipping specifically-excluded #{source} event type #{entry[:event_type].inspect} for #{entry[:event_title]}"
+        next
       else
         # This event type has been successfully mapped! :D
         entry[:event_type] = new_et['map_event_type']

--- a/events_airtable.rb
+++ b/events_airtable.rb
@@ -50,6 +50,10 @@ class EventTypeDictionary < Airrecord::Table
       old_et = entry[:event_type].to_s.strip.downcase
       new_et = dict[source][old_et]
 
+      # Save the original event type for debugging / figuring out what to
+      # exclude
+      entry[:orig_event_type] = entry[:event_type]
+
       if new_et.blank?
         # This event type is unrecognized; warn but keep it
         puts "Unmapped #{source} event type #{entry[:event_type].inspect} for #{entry[:event_title]}"

--- a/events_airtable.rb
+++ b/events_airtable.rb
@@ -57,12 +57,16 @@ class EventTypeDictionary < Airrecord::Table
       elsif new_et.blank?
         # This event type is unrecognized; warn but keep it
         puts "Unmapped #{source} event type #{entry[:event_type].inspect} for #{entry[:event_title]}"
-        entry[:exclude_from_carousel] = false
         list << entry
       else
         # This event type has been successfully mapped! :D
         entry[:event_type] = new_et['map_event_type']
-        entry[:exclude_from_carousel] = !!new_et['exclude_from_carousel']
+
+        # Record if this event type is specifically excluded from the carousel
+        if new_et['exclude_from_carousel']
+          entry[:include_on_carousel] = false
+        end
+
         list << entry
       end
     end

--- a/every_action.rb
+++ b/every_action.rb
@@ -80,7 +80,7 @@ class EveryActionEvent
       location_name: location['name'],
       event_source: 'everyaction',
       event_type: event_type,
-      is_national: true,
+      include_on_carousel: true, # by default, EA events are on the carousel
       description: data['description'],
       event_title: data['name'],
       registration_link: registration_link,

--- a/mobilize_america.rb
+++ b/mobilize_america.rb
@@ -81,7 +81,7 @@ class MobilizeAmericaEvent
       event_source: 'mobilize',
       event_type: data['event_type'],
       event_title: data['title'],
-      is_national: is_national,
+      include_on_carousel: is_national, # show national MA events on carousel
       description: data['description'],
       location_name: location['venue'],
       featured_image_url: data['featured_image_url'],


### PR DESCRIPTION
This PR:
- Replaces `is_national` with `include_on_carousel`, which is true if an event is determined to be "national" and if it's not excluded by the event types table on Airtable
- Adds `orig_event_type` to the JSON which shows the type of the event before it was mapped, so mapping issues will be easier to diagnose and debug